### PR TITLE
Updating shebang to indicate POSIX compatibility

### DIFF
--- a/tilish.tmux
+++ b/tilish.tmux
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # vim: foldmethod=marker
 
 # Project: tmux-tilish


### PR DESCRIPTION
Because this script doesn't use any [bashisms](https://mywiki.wooledge.org/Bashism), it should be fully POSIX-compatible. Giving it the header `/bin/sh` indicates this, and means that people who have [dash](https://wiki.archlinux.org/index.php/Dash) symlinked in this location can take advantage of its extra speed.

I'm familiar with purpose of using the `#!/usr/bin/env bash` for Mac compatibility, and in this case using `/bin/sh` shouldn't cause any issues, again because it's a POSIX-compliant script. It all worked fine when I tested it on my MBP. Thanks for writing this!