### PR TITLE
Apply suggestions from `shellcheck`

### DIFF
--- a/tilish.tmux
+++ b/tilish.tmux
@@ -13,19 +13,19 @@
 # Check input parameters {{{
 	# Whether we need to use legacy workarounds (required before tmux 2.7).
 	legacy="$(tmux -V | grep -E 'tmux (1\.|2\.[0-6])')"
-	
+
 	# Read user options.
 	for opt in default dmenu easymode navigate navigator prefix shiftnum
 	do
 		export "$opt"="$(tmux show-option -gv @tilish-$opt 2>/dev/null)"
 	done
-	
+
 	# Default to US keyboard layout, unless something is configured.
 	if [ -z "$shiftnum" ]
 	then
 		shiftnum='!@#$%^&*()'
 	fi
-	
+
 	# Determine "arrow types".
 	if [ "$easymode" = "on" ]
 	then
@@ -37,7 +37,7 @@
 		h='h'; j='j'; k='k'; l='l';
 		H='H'; J='J'; K='K'; L='L';
 	fi
-	
+
 	# Determine modifier vs. prefix key.
 	if [ -z "$prefix" ]
 	then
@@ -222,7 +222,7 @@ then
 	# Autorefresh layout after deleting a pane.
 	tmux set-hook -g after-split-window "select-layout; select-layout -E"
 	tmux set-hook -g pane-exited "select-layout; select-layout -E"
-	
+
 	# Autoselect layout after creating new window.
 	if [ -n "$default" ]
 	then
@@ -246,12 +246,12 @@ then
 	# If `@tilish-navigator` is nonzero, integrate Alt + hjkl with `vim-tmux-navigator`.
 	# This assumes that your Vim/Neovim is setup to use Alt + hjkl bindings as well.
 	is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-	
+
 	tmux $bind "${mod}${h}" if-shell "$is_vim" 'send M-h' 'select-pane -L'
 	tmux $bind "${mod}${j}" if-shell "$is_vim" 'send M-j' 'select-pane -D'
 	tmux $bind "${mod}${k}" if-shell "$is_vim" 'send M-k' 'select-pane -U'
 	tmux $bind "${mod}${l}" if-shell "$is_vim" 'send M-l' 'select-pane -R'
-	
+
 	if [ -z "$prefix" ]
 	then
 		tmux bind -T copy-mode-vi "M-$h" select-pane -L


### PR DESCRIPTION
I applied suggestions from [`shellcheck`](https://github.com/koalaman/shellcheck), a shell script static analysis tool.

I disabled the following errors:

- [SC2003](https://github.com/koalaman/shellcheck/wiki/SC2003): `expr is antiquated. Consider rewriting this using $((..)), ${} or [[ ]].`

  You use `expr` a lot, but I'm not familiar with it or how I'd rewrite it as `shellcheck` suggests.

- [SC2016](https://github.com/koalaman/shellcheck/wiki/SC2016): `Expressions don't expand in single quotes, use double quotes for that.`

  I believe these errors are false positives. `shellcheck` might not understand when you want the `$variable`s to be evaluated in the shell being invoked (e.g. `sh -c 'echo $USER'`).

- [SC2250](https://github.com/koalaman/shellcheck/wiki/SC2250): `Prefer putting braces around variable references even when not strictly required.`

  This error is optional, but I have all errors enabled on my machine. This was the only optional error it complained about. I disabled it to avoid disrupting the code more than necessary.