### PR TITLE
preserve pane arrangement on refresh

### DIFF
--- a/tilish.tmux
+++ b/tilish.tmux
@@ -68,7 +68,6 @@ bind_move () {
 			if-shell "tmux join-pane -t :$2" \
 				"" \
 				"new-window -dt :$2; join-pane -t :$2; select-pane -t top-left; kill-pane" \\\;\
-			select-layout \\\;\
 			select-layout -E
 	else
 		tmux $bind "$1" \
@@ -232,9 +231,9 @@ tmux $bind "${mod}C" \
 # Define hooks {{{
 if [ -z "$legacy" ]
 then
-	# Autorefresh layout after deleting a pane.
-	tmux set-hook -g after-split-window "select-layout; select-layout -E"
-	tmux set-hook -g pane-exited "select-layout; select-layout -E"
+	# Autorefresh layout after creating/deleting a pane.
+	tmux set-hook -g after-split-window "select-layout -E"
+	tmux set-hook -g pane-exited "select-layout -E"
 
 	# Autoselect layout after creating new window.
 	if [ -n "${default:-}" ]


### PR DESCRIPTION
Hello! 

I have been using this plugin for nearly a year now and it has been a tremendous productivity gain for me.

However, it always bugged me that when I accidentally apply a preset layout, I would basically lose the ability to configure the pane arrangement of that window and need to move all my panes to another window.

I thought this was intentional, but maybe not?

Thanks and great project!