### PR TITLE
Add createauto option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ bindings are "smart": depending on `base-index`, they either act on workspace 0 
 Moreover, if you press <kbd>Alt</kbd> + <kbd>3</kbd> to switch to workspace 3 and then
 press it again, you will be sent back to the previous workspace you were using.
 
+The  <kbd>Alt</kbd> + <kbd>0</kbd>-<kbd>9</kbd> will create a new workspace if
+one does not exist. This option can be turned off by the configuration
+`@tilish-createauto` as follows:
+
+    set -g @tilish-createauto 'off'
+
+When set to off, this setting will silently ignore when a non-existing
+workspace is selected. This prevents accidental creation of workspaces. Note
+that this configuration does not change the move pane to workspace command
+<kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>0</kbd>-<kbd>9</kbd>, which will
+create a new workspace.
+
 These keybindings can be changed by using a configuration setting `@tilish-remap`,
 which is somewhat similar to `vim`'s `nnoremap` command. The way it works is
 that you specify which keys you want to remap in the following format. For instance,

--- a/tilish.tmux
+++ b/tilish.tmux
@@ -19,7 +19,7 @@
 	legacy="$(tmux -V | grep -E 'tmux (1\.|2\.[0-6])')"
 
 	# Read user options.
-	for opt in default dmenu easymode enforce navigate navigator prefix project remap shiftnum; do
+	for opt in createauto default dmenu easymode enforce navigate navigator prefix project remap shiftnum; do
 		export "$opt"="$(tmux show-option -gv @tilish-"$opt" 2>/dev/null)"
 	done
 
@@ -60,11 +60,19 @@
 
 # Define core functionality {{{
 	bind_switch() {
+		# If createauto is set off, then only create new session with mod-#num
+		# otherwise silently ignore (default case)
+		if [ "${createauto}" = "off" ]; then
+			newwincmd=''
+		else
+			newwincmd="new-window -t :""$2"
+		fi
 		# Bind keys to switch to a workspace. The workspace is created if it
 		# doesn't exist, and if we're already there we go back to the last one.
+		#
 		tmux $bind "$1" \
 			if-shell '[ "$(tmux display -p "#I")" != "'"$2"'" ]' \
-			"if-shell 'tmux select-window -t :$2' '' 'new-window -t :$2'" \
+			"if-shell 'tmux select-window -t :$2' '' '$newwincmd'" \
 			"last-window"
 	}
 


### PR DESCRIPTION
Mod 0-9 creates a new workspace if one does not exist. Accidentally hitting an incorrect number will create a new workspace. Add a new option to silently ignore non-existing workspaces.