### PR TITLE
feat: add smartsplits support

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,16 +306,15 @@ Alternatively, `tilish` also supports a [Prefix mode](#prefix-mode). This is in 
 less ergonomic than the default `tilish` keybindings. However, it does not require the use
 of <kbd>Alt</kbd>, and is therefore compatible with the default `i3wm` keybindings.
 
-## Integration with vim
+## Integration with vim/neovim
 
-There are multiple great plugins, [tmux-navigate][10], [vim-tmux-navigator][3],
-[smart-splits.nvim][11], which both allow seamless navigation between `vim`
-splits and `tmux` splits.
-[tmux-navigate][10] has an advantage that it also works over `ssh` connections,
-and that it plays better with zooming (<kbd>Alt</kbd>+<kbd>z</kbd>).  If you
-use either plugin, you can tell `tilish` to make it setup the keybindings for
-you. (If you don't, `tilish` will use fallback keybindings that don't integrate
-with `vim`.)
+There are multiple great plugins [tmux-navigate][10], [vim-tmux-navigator][3],
+[smart-splits.nvim][11], which all allow seamless navigation between `vim`
+splits and `tmux` splits. [tmux-navigate][10] has an advantage that it also
+works over `ssh` connections, and that it plays better with zooming
+(<kbd>Alt</kbd>+<kbd>z</kbd>). If you use these plugins, you can tell `tilish`
+to make it setup the keybindings for you as described below. (If you don't,
+`tilish` will use fallback keybindings that don't integrate with `vim`.)
 
 ### Navigate
 
@@ -381,8 +380,7 @@ A minimal working  example of a `~/.tmux.conf` with `tpm` would then be:
 
 Integration with [smart-splits][11] is achieved through setting the
 `@tilish-smartsplits` option to `on`. This automatically configures the
-keybindings so that <kbd>M</kbd>-<kbd>hjkl</kbd> permit navigating around
-panes.
+keybindings so that <kbd>M</kbd>-<kbd>hjkl</kbd> permit navigating around panes.
 
 Prior to that, it requires installing the `smart-splits.nvim` plugin and
 configuring the following keybindings in e.g. `~/.config/nvim/init.vim`:

--- a/README.md
+++ b/README.md
@@ -308,12 +308,14 @@ of <kbd>Alt</kbd>, and is therefore compatible with the default `i3wm` keybindin
 
 ## Integration with vim
 
-There are two great plugins [tmux-navigate][10] and [vim-tmux-navigator][3],
-which both allow seamless navigation between `vim` splits and `tmux` splits.
-The former has an advantage that it also works over `ssh` connections, and that
-it plays better with zooming (<kbd>Alt</kbd>+<kbd>z</kbd>).  If you use either
-plugin, you can tell `tilish` to make it setup the keybindings for you. (If you
-don't, `tilish` will use fallback keybindings that don't integrate with `vim`.)
+There are multiple great plugins, [tmux-navigate][10], [vim-tmux-navigator][3],
+[smart-splits.nvim][11], which both allow seamless navigation between `vim`
+splits and `tmux` splits.
+[tmux-navigate][10] has an advantage that it also works over `ssh` connections,
+and that it plays better with zooming (<kbd>Alt</kbd>+<kbd>z</kbd>).  If you
+use either plugin, you can tell `tilish` to make it setup the keybindings for
+you. (If you don't, `tilish` will use fallback keybindings that don't integrate
+with `vim`.)
 
 ### Navigate
 
@@ -375,8 +377,38 @@ A minimal working  example of a `~/.tmux.conf` with `tpm` would then be:
 	# Activate the plugins.
 	run -b "~/.tmux/plugins/tpm/tpm"
 
+### Smart-splits (neovim)
+
+Integration with [smart-splits][11] is achieved through setting the
+`@tilish-smartsplits` option to `on`. This automatically configures the
+keybindings so that <kbd>M</kbd>-<kbd>hjkl</kbd> permit navigating around
+panes.
+
+Prior to that, it requires installing the `smart-splits.nvim` plugin and
+configuring the following keybindings in e.g. `~/.config/nvim/init.vim`:
+
+```lua
+  -- moving between splits
+  vim.keymap.set("n", "<A-h>", require("smart-splits").move_cursor_left)
+  vim.keymap.set("n", "<A-k>", require("smart-splits").move_cursor_up)
+  vim.keymap.set("n", "<A-j>", require("smart-splits").move_cursor_down)
+  vim.keymap.set("n", "<A-l>", require("smart-splits").move_cursor_right)
+  vim.keymap.set("n", "<A-\\>", require("smart-splits").move_cursor_previous)
+  -- resizing splits
+  vim.keymap.set("n", "<C-h>", require("smart-splits").resize_left)
+  vim.keymap.set("n", "<C-j>", require("smart-splits").resize_down)
+  vim.keymap.set("n", "<C-k>", require("smart-splits").resize_up)
+  vim.keymap.set("n", "<C-l>", require("smart-splits").resize_right)
+  -- swapping buffers between windows
+  vim.keymap.set("n", "<leader><leader>h", require("smart-splits").swap_buf_left)
+  vim.keymap.set("n", "<leader><leader>j", require("smart-splits").swap_buf_down)
+  vim.keymap.set("n", "<leader><leader>k", require("smart-splits").swap_buf_up)
+  vim.keymap.set("n", "<leader><leader>l", require("smart-splits").swap_buf_right)
+```
+
 [3]:  https://github.com/christoomey/vim-tmux-navigator
 [10]: https://github.com/sunaku/tmux-navigate
+[11]: https://github.com/mrjones2014/smart-splits.nvim
 
 # Related projects
 
@@ -385,3 +417,4 @@ A minimal working  example of a `~/.tmux.conf` with `tpm` would then be:
 - [tmux-navigate](https://github.com/sunaku/tmux-navigate)
 - [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator)
 - [vim-i3wm-tmux-navigator](https://github.com/fogine/vim-i3wm-tmux-navigator)
+- [smart-splits.nvim](https://github.com/mrjones2014/smart-splits.nvim)

--- a/tilish.tmux
+++ b/tilish.tmux
@@ -177,12 +177,10 @@
 	tmux $bind "${mod}${O}" swap-pane -D
 
 	# Switch to pane via Alt + hjkl.
-	if [ "${smartsplits:-}" != "on" ]; then
-		tmux $bind "${mod}${h}" select-pane -L
-		tmux $bind "${mod}${j}" select-pane -D
-		tmux $bind "${mod}${k}" select-pane -U
-		tmux $bind "${mod}${l}" select-pane -R
-	fi
+	tmux $bind "${mod}${h}" select-pane -L
+	tmux $bind "${mod}${j}" select-pane -D
+	tmux $bind "${mod}${k}" select-pane -U
+	tmux $bind "${mod}${l}" select-pane -R
 
 	# Move a pane via Alt + Shift + hjkl.
 	if [ -z "$legacy" ]; then
@@ -282,14 +280,13 @@
 		fi
 	elif [ "${smartsplits:-}" = "on" ]; then
 		# If `@tilish-smartsplits` is nonzero, integrate Alt + hjkl with `smart-splits.nvim`.
-		# This assumes that your Vim/Neovim is setup to use Alt + hjkl bindings as well.
-		
+		# This assumes that your Vim/Neovim is setup to use Alt + hjkl bindings as well.	
 		tmux $bind "${mod}${h}" if -F "#{@pane-is-vim}" 'send M-h'  'select-pane -L'
 		tmux $bind "${mod}${j}" if -F "#{@pane-is-vim}" 'send M-j'  'select-pane -D'
 		tmux $bind "${mod}${k}" if -F "#{@pane-is-vim}" 'send M-k'  'select-pane -U'
 		tmux $bind "${mod}${l}" if -F "#{@pane-is-vim}" 'send M-l'  'select-pane -R'
 
-		# Smart pane resizing with awareness of Neovim splits. tmux escape then C-hjkl to resize
+		# Smart pane resizing with awareness of Neovim splits. tmux escape then C-hjkl to resize.
 		tmux bind -r C-h if -F "#{@pane-is-vim}" 'send-keys C-h' 'resize-pane -L 7'
 		tmux bind -r C-j if -F "#{@pane-is-vim}" 'send-keys C-j' 'resize-pane -D 7'
 		tmux bind -r C-k if -F "#{@pane-is-vim}" 'send-keys C-k' 'resize-pane -U 7'


### PR DESCRIPTION
adds a new `tilish-smartsplits` option which prevents binding the default `M-hjkl` to switch panes. the binding is instead configured in `tmux.conf`, according to what is defined in the [smart-splits documentation](https://github.com/mrjones2014/smart-splits.nvim?tab=readme-ov-file#tmux) 

I'm not sure how this should be documented, that's why I didn't edit the README yet. let me know if you want me to document a 3rd (neo-)vim integration.